### PR TITLE
New CLI options and bugfixes.

### DIFF
--- a/blob.py
+++ b/blob.py
@@ -111,8 +111,8 @@ def download(context, backend, handle, output, format):
 )
 @click.option(
     "--theme",
-    default="DEFAULT",
-    type=click.Choice(["DEFAULT", "FESTIVE"], case_sensitive=False),
+    default="NORMAL",
+    type=click.Choice(["NORMAL", "FESTIVE"], case_sensitive=False),
 )
 @click.option(
     "--language",
@@ -132,7 +132,7 @@ def download(context, backend, handle, output, format):
 )
 @click.pass_obj
 @click.pass_context
-def create(context, backend, input, output, format, theme, tempo, language, phoneme_fill_in):
+def create(context, backend, input, output, format, theme, tempo, language, tracks, phoneme_fill_in):
     """Create a recording from the given MusicXML file."""
     if language == "GENERIC":
         language = Generic
@@ -144,6 +144,7 @@ def create(context, backend, input, output, format, theme, tempo, language, phon
         theme=Theme[theme],
         language=language,
         tempo=tempo,
+        tracks=tracks,
         phoneme_fill_in=Phoneme[phoneme_fill_in]
     )
     

--- a/blob.py
+++ b/blob.py
@@ -156,7 +156,7 @@ def create(
 
     data = music21.converter.parse(input)
     score = Score(
-        data=data,
+        stream=data,
         theme=Theme[theme],
         language=language,
         tempo=tempo,

--- a/blob.py
+++ b/blob.py
@@ -11,6 +11,7 @@ from requests.exceptions import RequestException
 from blob.backend import Backend
 from blob.music import Score
 from blob.themes import Theme
+from blob.phonemes import Phoneme
 from blob.protocol import RecordingMessage, RecordedLibrettos, JitterTemplates
 
 
@@ -109,16 +110,26 @@ def download(context, backend, handle, output, format):
 )
 @click.option(
     "--theme",
-    default="NORMAL",
-    type=click.Choice(["NORMAL", "FESTIVE"], case_sensitive=False),
+    default="DEFAULT",
+    type=click.Choice(["DEFAULT", "FESTIVE"], case_sensitive=False),
 )
 @click.option("--tempo", default=1.0, type=float)
+@click.option(
+    "--tracks",
+    default="AUTO",
+    type=str,
+)
+@click.option(
+    "--phoneme_fill_in",
+    default="SIL",
+    type=click.Choice(["SIL", "A", "E", "I", "O", "U"], case_sensitive=False)
+)
 @click.pass_obj
 @click.pass_context
-def create(context, backend, input, output, format, theme, tempo):
+def create(context, backend, input, output, format, theme, tempo, tracks,phoneme_fill_in):
     """Create a recording from the given MusicXML file."""
     music = music21.converter.parse(input)
-    data = json.dumps(Score(music, theme=Theme[theme], tempo=tempo).data())
+    data = json.dumps(Score(music, theme=Theme[theme], tempo=tempo, tracks=tracks, phoneme_fill_in=Phoneme[phoneme_fill_in]).data())
     context.invoke(
         convert_recording,
         input=data.encode(),

--- a/blob.py
+++ b/blob.py
@@ -122,30 +122,46 @@ def download(context, backend, handle, output, format):
 @click.option("--tempo", default=1.0, type=float)
 @click.option(
     "--tracks",
-    default="AUTO",
-    type=str,
+    default=(0, 1, -2, -1),
+    type=int,
+    nargs=4,
+    help="Indexes for soprano, alto, tenor and bass.",
+    show_default=True
 )
 @click.option(
-    "--phoneme_fill_in",
+    "--fill",
     default="SIL",
-    type=click.Choice(["SIL", "A", "E", "I", "O", "U"], case_sensitive=False)
+    type=click.Choice(["SIL", "A", "E", "I", "O", "U"], case_sensitive=False),
+    help="Fill in phoneme for tracks without lyrics."
 )
 @click.pass_obj
 @click.pass_context
-def create(context, backend, input, output, format, theme, tempo, language, tracks, phoneme_fill_in):
+def create(
+    context,
+    backend,
+    input,
+    output,
+    format,
+    theme,
+    tempo,
+    language,
+    tracks,
+    fill
+):
     """Create a recording from the given MusicXML file."""
     if language == "GENERIC":
         language = Generic
     if language == "RANDOM":
         language = Random
 
+    data = music21.converter.parse(input)
     score = Score(
-        music21.converter.parse(input),
+        data=data,
         theme=Theme[theme],
         language=language,
         tempo=tempo,
-        tracks=tracks,
-        phoneme_fill_in=Phoneme[phoneme_fill_in]
+        tracks=(0, 0, 0, 0) if len(data.stream.parts) == 1 else tracks,
+        fill=Phoneme[fill]
     )
     
     context.invoke(

--- a/blob.py
+++ b/blob.py
@@ -160,7 +160,7 @@ def create(
         theme=Theme[theme],
         language=language,
         tempo=tempo,
-        tracks=(0, 0, 0, 0) if len(data.stream.parts) == 1 else tracks,
+        tracks=(0, 0, 0, 0) if len(data.parts) == 1 else tracks,
         fill=Phoneme[fill]
     )
     

--- a/blob/lyrics.py
+++ b/blob/lyrics.py
@@ -41,7 +41,7 @@ class Suffix:
     """
 
     def __init__(
-        self, phonemes: Optional[List[Phoneme]] = None, *, strict: bool = True
+        self, phonemes: Optional[List[Phoneme]] = None, *, strict: bool = False
     ):
         # Retrieve the the suffix or use silence as default value
         suffix = phonemes or [Phoneme.SIL]

--- a/blob/music.py
+++ b/blob/music.py
@@ -34,7 +34,7 @@ class Score:
         ):
             raise ValueError("track index out of bounds")
         self.parts = [
-            Part(self.stream.parts[track], self.language, self.tempo)
+            Part(self.stream.parts[track], self.language, self.tempo, fill=self.fill)
             for track in self.tracks
         ]
 
@@ -125,8 +125,7 @@ class Part:
         # Update the class variables with the pertaining object representations
         self.sounds = []
         for sound in sounds:
-            # sound = {**val}
-            sound['time'] =  sound["time"] * (1 / self.tempo)
+            sound['time'] = sound["time"] * (1 / self.tempo)
             self.sounds.append(Sound(**sound))
 
         self.start = Suffix(start)

--- a/blob/protocol/code/__init__.py
+++ b/blob/protocol/code/__init__.py
@@ -17,10 +17,11 @@ from google.protobuf.internal.enum_type_wrapper import EnumTypeWrapper
 def build(input: Path, output: Path, arguments: Optional[dict] = None):
     """Build all the *.proto source files from input to output."""
     if arguments is None:
-        arguments = {
-            "--proto_path": str(input),
-            "--python_out": str(output)
-        }
+        arguments = {}
+    arguments.update({
+        "--proto_path": str(input),
+        "--python_out": str(output)
+    })
     arguments = sum(zip(arguments.keys(), arguments.values()), tuple())
     protoc.main(["protoc", *arguments, *map(str, input.rglob("*.proto"))])
 

--- a/blob/protocol/code/__init__.py
+++ b/blob/protocol/code/__init__.py
@@ -16,9 +16,10 @@ from google.protobuf.internal.enum_type_wrapper import EnumTypeWrapper
 
 def build(input: Path, output: Path, arguments: Optional[dict] = None):
     """Build all the *.proto source files from input to output."""
-    arguments = (arguments or {}) | {
-        "--proto_path": str(input),
-        "--python_out": str(output)
+    if arguments is None:
+        arguments = {
+            "--proto_path": str(input),
+            "--python_out": str(output)
         }
     arguments = sum(zip(arguments.keys(), arguments.values()), tuple())
     protoc.main(["protoc", *arguments, *map(str, input.rglob("*.proto"))])


### PR DESCRIPTION
Thank you for making this library! @JudahDoupe and I had a lot of fun playing around with it. While using it we added a couple of new options to the CLI. Any feedback is welcome! 

# CLI Options

The first is the ability to select what tracks you want to use from an MXL file. We found useable songs that would have an extra tenor or a percussion track that would bring it over the track limit of 4. Now you can select the tracks by passing in a comma-separated list `--tracks=0,2,4,5`. The order can be changed as well `--tracks=4,1,5,3`.

The second is letting a user specify what the initial `last` phoneme should be. This proved to be very useful because there are a lot of SATB choral arrangements that don't have any phonemes embedded within them.  Providing a new default produces a song that works. It's not perfect but greatly increases the number of available songs.  This also fixed an arrangement where only the tenor had phonemes by filling in the other parts. 

# Bugfixes
The main bugfix was converting everything that used this syntax to if statements.

```
   arguments = (arguments or {}) | {
        "--proto_path": str(input),	       
        "--python_out": str(output)	        
            "--python_out": str(output)
     }
```
This would cause this error for us.
```
   arguments = (arguments or {}) | {
   TypeError: unsupported operand type(s) for |: 'dict' and 'dict'
```

The other fix was to allow events that have an empty phoneme list.  It would crash if an arrangement contained data formatted that way.   
